### PR TITLE
replace joda with java time, bump versions

### DIFF
--- a/argus/src/main/scala/argus/macros/CirceCodecBuilder.scala
+++ b/argus/src/main/scala/argus/macros/CirceCodecBuilder.scala
@@ -14,13 +14,14 @@ class CirceCodecBuilder[U <: Universe](val u: U) extends CodecBuilder {
     q"import cats.syntax.either._" ::
     q"import io.circe._" ::
     q"import io.circe.syntax._" ::
+    q"import io.circe.java8.time._" ::
     Nil
 
   def inEncoder(typ: Tree) = tq"Encoder[$typ]"
 
   def inDecoder(typ: Tree) = tq"Decoder[$typ]"
 
-  def constants = anyEncoder :: anyDecoder :: dateTimeEncoder :: dateTimeDecoder :: Nil
+  def constants = anyEncoder :: anyDecoder :: Nil
 
   val anyEncoder = q"""
     def anyEncoder: Encoder[Any] = Encoder.instance((a: Any) => a match {
@@ -56,24 +57,6 @@ class CirceCodecBuilder[U <: Universe](val u: U) extends CodecBuilder {
       case o if o.isObject =>  o.as[Map[String, Any]](Decoder.decodeMapLike(KeyDecoder.decodeKeyString, anyDecoder, Map.canBuildFrom))
       case a if a.isArray =>   a.as[List[Any]](Decoder.decodeCanBuildFrom(anyDecoder, List.canBuildFrom[Any]))
     })
-  """
-
-  val dateTimeEncoder = q"""
-    implicit val dateTimeEncoder: Encoder[org.joda.time.DateTime] = Encoder.instance(dt => dt.toString(org.joda.time.format.ISODateTimeFormat.dateTime().withOffsetParsed).asJson);
-  """
-
-  val dateTimeDecoder = q"""
-    implicit val dateTimeDecoder: Decoder[org.joda.time.DateTime] = Decoder.instance((c: HCursor) =>
-      for {
-        json <- c.as[Json]
-        strJson <- json.asString.map(Either.right).getOrElse(Either.left(DecodingFailure("DateTime", c.history)))
-        dt <- try {
-          Either.right(org.joda.time.DateTime.parse(json.asString.get, org.joda.time.format.ISODateTimeFormat.dateTime().withOffsetParsed))
-        } catch {
-          case error: Exception => Either.left(DecodingFailure(error.getMessage, c.history))
-        }
-      } yield dt
-    )
   """
 
   def mkAnyWrapperEncoder(typ: Tree) = q"""

--- a/argus/src/main/scala/argus/macros/ModelBuilder.scala
+++ b/argus/src/main/scala/argus/macros/ModelBuilder.scala
@@ -34,7 +34,7 @@ class ModelBuilder[U <: Universe](val u: U) {
     case (SimpleTypes.Number, Some(Formats.Single)) => tq"Float"
     case (SimpleTypes.Number, _) => tq"Double"
     case (SimpleTypes.String, Some(Formats.Uuid)) => tq"java.util.UUID"
-    case (SimpleTypes.String, Some(Formats.DateTime)) => tq"org.joda.time.DateTime"
+    case (SimpleTypes.String, Some(Formats.DateTime)) => tq"java.time.ZonedDateTime"
     case (SimpleTypes.String, _) => tq"String"
     case (SimpleTypes.Null, _) => tq"Null"
     case _ => throw new Exception("Type isn't a known intrinsic type " + st)

--- a/argus/src/test/scala/argus/macros/CirceCodecBuilderSpec.scala
+++ b/argus/src/test/scala/argus/macros/CirceCodecBuilderSpec.scala
@@ -137,8 +137,8 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
     val res = codecBuilder.mkCodec(defs)
 
     res collect extractCodecNameAndType should contain theSameElementsAs
-      List(("dateTimeEncoder", "Encoder[org.joda.time.DateTime]"), ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]"),
-        ("FooEncoder","Encoder[Foo]"), ("FooDecoder","Decoder[Foo]"), ("BarEncoder","Encoder[Bar]"), ("BarDecoder","Decoder[Bar]"))
+      List(("FooEncoder","Encoder[Foo]"), ("FooDecoder","Decoder[Foo]"), ("BarEncoder","Encoder[Bar]"),
+        ("BarDecoder","Decoder[Bar]"))
   }
 
   it should "ignore other definitions" in {
@@ -148,16 +148,14 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
         Nil
 
     val res = codecBuilder.mkCodec(defs) collect extractCodecNameAndType
-    res should contain theSameElementsAs List(("dateTimeEncoder", "Encoder[org.joda.time.DateTime]"),
-      ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]"))
+    res should contain theSameElementsAs Nil
   }
 
   it should "work with nested case classes" in {
     val defs = List(q"object Root { object Foo { case class Bar(a: Int) } }")
     val res = codecBuilder.mkCodec(defs)
     res collect extractCodecNameAndType should contain theSameElementsAs
-      List(("dateTimeEncoder", "Encoder[org.joda.time.DateTime]"), ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]"),
-        ("RootFooBarEncoder","Encoder[Root.Foo.Bar]"), ("RootFooBarDecoder","Decoder[Root.Foo.Bar]"))
+      List(("RootFooBarEncoder","Encoder[Root.Foo.Bar]"), ("RootFooBarDecoder","Decoder[Root.Foo.Bar]"))
   }
 
   it should "add an encoder/decoder for each @enum" in {
@@ -174,9 +172,7 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
     val res = codecBuilder.mkCodec(defs)
 
     res collect extractCodecNameAndType should contain theSameElementsAs
-      ("dateTimeEncoder", "Encoder[org.joda.time.DateTime]") ::
-        ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]") ::
-        ("FooEncoder","Encoder[Foo]") ::
+      ("FooEncoder","Encoder[Foo]") ::
         ("FooDecoder","Decoder[Foo]") ::
         Nil
 
@@ -194,9 +190,7 @@ class CirceCodecBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
 
     val res = codecBuilder.mkCodec(defs)
     res collect extractCodecNameAndType should contain theSameElementsAs
-      ("dateTimeEncoder", "Encoder[org.joda.time.DateTime]") ::
-        ("dateTimeDecoder", "Decoder[org.joda.time.DateTime]") ::
-        ("FooEncoder","Encoder[Foo]") ::
+      ("FooEncoder","Encoder[Foo]") ::
         ("FooDecoder","Decoder[Foo]") ::
         Nil
 

--- a/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
+++ b/argus/src/test/scala/argus/macros/FromSchemaSpec.scala
@@ -1,6 +1,7 @@
 package argus.macros
 
 import java.io.File
+import java.time.ZonedDateTime
 import java.util.UUID
 
 import argus.json.JsonDiff
@@ -9,8 +10,6 @@ import org.scalatest.{FlatSpec, Matchers}
 import cats.syntax.either._
 import io.circe._
 import io.circe.syntax._
-import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormat
 
 import scala.io.Source
 
@@ -312,7 +311,7 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
     root.id should === (Some(UUID.fromString(uuid)))
   }
 
-  it should "encode DateTime type" in {
+  it should "encode ZonedDateTime type" in {
     @fromSchemaJson("""
     {
       "type": "object",
@@ -329,9 +328,8 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
     import Foo.Implicits._
     import io.circe.syntax._
 
-
-    val dateTime = "2017-01-01T10:00:00.000Z"
-    val root = Root(Some(DateTime.parse(dateTime)))
+    val dateTime = "2017-01-01T10:00:00.001Z"
+    val root = Root(Some(ZonedDateTime.parse(dateTime)))
     root.asJson should beSameJsonAs (s"""
                                         |{
                                         |  "createdAt": "$dateTime"
@@ -339,7 +337,7 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
                                      """.stripMargin)
   }
 
-  it should "decode DateTime type" in {
+  it should "decode ZonedDateTime type" in {
     @fromSchemaJson("""
     {
       "type": "object",
@@ -355,7 +353,7 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
     import Foo._
     import Foo.Implicits._
 
-    val dateTime = "2017-01-01T10:00:00.000Z"
+    val dateTime = "2017-01-01T10:00:00.001Z"
     val json =
       s"""
          |{
@@ -364,7 +362,7 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
       """.stripMargin
     val root = parser.decode[Root](json).toOption.get
 
-    root.createdAt should === (Some(DateTime.parse(dateTime)))
+    root.createdAt should === (Some(ZonedDateTime.parse(dateTime)))
   }
 
   it should "return an error on decoding for datetime with wrong format" in {
@@ -394,7 +392,7 @@ class FromSchemaSpec extends FlatSpec with Matchers with JsonMatchers {
 
     root should be ('left)
     root.left.get match {
-      case d: DecodingFailure => d.message should === ("Invalid format: \"wrongDateTime\"")
+      case d: DecodingFailure => d.getMessage should === ("ZonedDateTime: DownField(createdAt)")
       case e@_ => fail(s"Wrong error type: ${e.getClass.getName}")
     }
   }

--- a/argus/src/test/scala/argus/macros/ModelBuilderSpec.scala
+++ b/argus/src/test/scala/argus/macros/ModelBuilderSpec.scala
@@ -33,7 +33,7 @@ class ModelBuilderSpec extends FlatSpec with Matchers with ASTMatchers {
 
   it should "create types with format for string type" in {
     mb.mkIntrinsicType(SimpleTypes.String, Some(Formats.Uuid)) should === (tq"java.util.UUID")
-    mb.mkIntrinsicType(SimpleTypes.String, Some(Formats.DateTime)) should === (tq"org.joda.time.DateTime")
+    mb.mkIntrinsicType(SimpleTypes.String, Some(Formats.DateTime)) should === (tq"java.time.ZonedDateTime")
   }
 
   it should "create types with unknown or incompatible formats" in {

--- a/build.sbt
+++ b/build.sbt
@@ -1,17 +1,16 @@
 import ReleaseTransformations._
 
 lazy val Vers = new {
-  val circe = "0.7.0"
+  val circe = "0.8.0"
   val scalatest = "3.0.1"
-  val jodaTime = "2.9.9"
 }
 
 lazy val commonSettings = Seq(
   name := "Argus",
   organization := "com.github.aishfenton",
-  scalaVersion := "2.12.1",
-  crossScalaVersions := Seq("2.11.8", "2.12.1"),
-  scalacOptions += "-target:jvm-1.7",
+  scalaVersion := "2.12.2",
+  crossScalaVersions := Seq("2.11.11", "2.12.2"),
+  scalacOptions += "-target:jvm-1.8",
   homepage := Some(url("https://github.com/aishfenton/Argus")),
   licenses := Seq("MIT License" -> url("http://www.opensource.org/licenses/MIT")),
 
@@ -90,8 +89,7 @@ lazy val argus = project.
       "io.circe" %% "circe-core" % Vers.circe,
       "io.circe" %% "circe-generic" % Vers.circe,
       "io.circe" %% "circe-parser" % Vers.circe,
-
-      "joda-time" % "joda-time" % Vers.jodaTime,
+      "io.circe" %% "circe-java8" % Vers.circe,
 
       "org.scalactic" %% "scalactic" % Vers.scalatest % Test,
       "org.scalatest" %% "scalatest" % Vers.scalatest % Test


### PR DESCRIPTION
@TugdualSarazin I switched out joda time with java time, and also bumped up the versions of circe and scala.